### PR TITLE
Modified and fixed pr-labeler.yml

### DIFF
--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,23 +1,15 @@
-name: Add Labels 
-# The events that triggers the workflow
+name: Add label to Merged PR
+
 on:
   pull_request_target:
-    branches:
-      - master
-    types:
-      - opened
+    types: [closed]
+
 
 jobs:
-  add-label:
-    name: Add Labels
-    # The machine each job should run
+  automate-issues-labels:
     runs-on: ubuntu-latest
-    # The tasks each job should run
     steps:
-      - uses: actions/checkout@v2
-      - uses: christianvuerings/add-labels@v1
+      - name: initial labeling
+        uses: andymckay/labeler@master
         with:
-          labels: |
-            GSSOC21
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          add-labels: 'GSSOC21'

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -5,7 +5,7 @@ on:
   pull_request_target:
     types: [closed]
 
-# The machine will reun each job
+# The machine will run each job when workflow will be triggered
 jobs:
   automate-issues-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/pr-labeler.yml
+++ b/.github/workflows/pr-labeler.yml
@@ -1,13 +1,15 @@
 name: Add label to Merged PR
 
+# The events for whcih this workflow wii be triggered
 on:
   pull_request_target:
     types: [closed]
 
-
+# The machine will reun each job
 jobs:
   automate-issues-labels:
     runs-on: ubuntu-latest
+    # These tasks will be run in each job
     steps:
       - name: initial labeling
         uses: andymckay/labeler@master


### PR DESCRIPTION
## Fixes #4009 

- pr-labeler of GitHub Action Not Working, Fixing the pr-labeler

fix #4009 

#### Replacing the .yml file

GitHub Action not Taking the .yml file in GitHub Action Workflow as a result. I will completely change the pr-labeler with the help of taking labeler and pr closed action. The job of this Action will be to add the GSSOC21 label on Merged PR.

## Trial Checking

I have Tried the Code on my Repository, GitHub Bot Adds the GSSOC21 Label Automatically after the PR is merged Successfully. Here is the Screenshot that Shows How the Workflow works!

![Capture](https://user-images.githubusercontent.com/73196470/119857293-0f8af600-bf31-11eb-9253-173567e65abf.JPG)
