### PR TITLE
Made Ceva's and Thales section responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -15208,7 +15208,10 @@
             <br>
             <p>Ceva’s theorem is a theorem regarding triangles in Euclidean Plane Geometry.</p>
             <p>Ceva's theorem is a theorem of affine geometry, in the sense that it may be stated and proved without using the concepts of angles, areas, and lengths (except for the ratio of the lengths of two line segments that are collinear). It is therefore true for triangles in any affine plane over any field.</p>
-            <img src="https://cdn1.byjus.com/wp-content/uploads/2020/10/Cevas-Theorem.png" alt="">
+            <div class="d-flex justify-content-center">
+                <img src="https://cdn1.byjus.com/wp-content/uploads/2020/10/Cevas-Theorem.png" style="width: 100%;" alt="">
+            </div>
+            
             <br>
             <p>Ceva's theorem is a theorem about triangles in plane geometry. Given a triangle ABC, let the lines AO, BO and CO be drawn from the vertices to a common point O, to meet opposite sides at D, E and F respectively.</p>
             <p>\[{\frac {AF}{FB}}\cdot {\frac {BD}{DC}}\cdot {\frac {CE}{EA}}=1\]</p>
@@ -15224,14 +15227,20 @@
             <br>
             <h6>Thales Theorem Statement</h6>
             <p>If a line is drawn parallel to one side of a triangle intersecting the other two sides in distinct points, then the other two sides are divided in the same ratio.</p>
-            <img src="https://cdn1.byjus.com/wp-content/uploads/2020/10/Basic-Proportionality-Theorem-Similar-TrianglesArtboard-1-8.png" alt="">
+            <div class="d-flex justify-content-center">
+                <img src="https://cdn1.byjus.com/wp-content/uploads/2020/10/Basic-Proportionality-Theorem-Similar-TrianglesArtboard-1-8.png" alt="" style="width: 100%;">
+            </div>
+            
             <p>\[\frac{AP}{PB}\space =\space \frac{AQ}{QC}\]</p>
             <p>The MidPoint theorem is a special case of the basic proportionality theorem. According to mid-point theorem, a line drawn joining the midpoints of the two sides of a triangle is parallel to the third side.</p>
             <br>
             <h6>Converse</h6>
             <br>
             <p>According to this theorem, if a line divides any two sides of a triangle in the same ratio, then the line is parallel to the third side.</p>
-            <img src="https://cdn1.byjus.com/wp-content/uploads/2020/10/Basic-Proportionality-Theorem-Similar-TrianglesArtboard-1-copy-3-8.png" alt="">
+            <div class="d-flex justify-content-center">
+                <img src="https://cdn1.byjus.com/wp-content/uploads/2020/10/Basic-Proportionality-Theorem-Similar-TrianglesArtboard-1-copy-3-8.png" alt="" style="width: 100%;">
+            </div>
+            
         </div>
         <div class="collapse" id="propcircle">
             <h2 style="text-align: center;">Properties of Circles</h2>


### PR DESCRIPTION
Fixed issue #4210 

I have made this section responsive.

screenshot:
![cevas-n](https://user-images.githubusercontent.com/66208607/119987668-e9259300-bfe2-11eb-9221-abbd2cf25055.png)

Please view my PR @sairish2001 