### PR TITLE
add separate subtraction of octal no. sys for fractional part mainly

### DIFF
--- a/appjs/logicjavascript.js
+++ b/appjs/logicjavascript.js
@@ -17359,6 +17359,23 @@ function subBinDecHexOct() {
             result.innerHTML = fracDectoBinHexOct(x3,2);
             work.innerHTML = "";
         }
+
+
+
+
+
+        
+        
+        
+        
+        else if(base === "Octal"){
+            x1 = calculatefrac(input1,8);
+            x2 = calculatefrac(input2,8);
+
+            x3 = x1 - x2;
+
+            result.innerHTML = fracDectoBinHexOct(x3,8);
+        }
     }else{
     if (input1.length > input2.length) {
         var p = input1.length - input2.length;


### PR DESCRIPTION
## Related Issue

@sairish2001 Adding a separate calculator was necessary because subtraction of fractional part isnt possible through complement method (which is used for normal subtraction of any no. sys)

fix #4439 
#### Describe the changes you've made

A clear and concise description of what you have done to successfully close your assigned issue. Any new files? or anything you feel to let us know!

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **original screenshot** | <b>updated screenshot </b> |
