### PR TITLE
Made Desargue's theorem section responsive

### DIFF
--- a/index.html
+++ b/index.html
@@ -15354,7 +15354,10 @@
                 concurrent, at a point called the center of perspectivity.
             </p>
             <br>
-            <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c8/Desargues_theorem_alt.svg/350px-Desargues_theorem_alt.svg.png" alt="">
+            <div class="d-flex justify-content-center">
+                <img src="https://upload.wikimedia.org/wikipedia/commons/thumb/c/c8/Desargues_theorem_alt.svg/350px-Desargues_theorem_alt.svg.png" alt="" style="width: 100%; max-width: 380px;">
+            </div>
+            
             <br>
             <p>This intersection theorem is true in the usual Euclidean plane but special care needs to be taken in exceptional cases, as when a pair of sides are parallel, so that their "point of intersection" 
                 recedes to infinity. Commonly, to remove these exceptions, mathematicians "complete" the Euclidean plane by adding points at infinity, following Jean-Victor Poncelet. This results in a projective plane.


### PR DESCRIPTION
Fix #4760 

I have made this section responsive.

Screenshot:

![desargues-n](https://user-images.githubusercontent.com/66208607/120113663-1fa50e80-c199-11eb-893e-3c3e9add652a.png)

Please view my PR @sairish2001 