### PR TITLE
Center alignment of text inside the calculator buttons

### DIFF
--- a/css/simplecal.css
+++ b/css/simplecal.css
@@ -48,7 +48,7 @@
     margin-top: 10px;
     background-color: var(--appblack);
     width: 100%;
-    text-align: right;
+    text-align: center;
     font-size: 1.5625rem;
     outline: none;
     overflow-wrap: break-word;


### PR DESCRIPTION
Fix: #5213

## Related Issue

- The words inside the calculator buttons were in the upper half and looked bad.

fix #5213 
#### Describe the changes you've made

I have made the text shift to centre for a better view.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [ ] My code follows the style guidelines of this project.
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **original screenshot** | <b>updated screenshot </b> |
