### PR TITLE
Centering the text inside the button in calculator

### DIFF
--- a/css/simplecal.css
+++ b/css/simplecal.css
@@ -72,7 +72,7 @@
     font-size: 1.5rem;
     margin: 10px 0 0 !important;
     color: var(--appwhite);
-    line-height: 40px;
+    line-height: 70px;
     height: 70px;
     width: 85px;
     border-radius: 10px;


### PR DESCRIPTION
Fix: #5213

## Related Issue

- The words inside the calculator buttons were in the upper half and looked bad.

fix #5213 

#### Describe the changes you've made

I have made the text shift to centre for a better view.

## Checklist:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [ ] My code follows the style guidelines of this project.
- [X] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **
![image](https://user-images.githubusercontent.com/72426535/121448426-417e6c80-c9b5-11eb-8329-95d4160e69f1.png)
** | <b>
![image](https://user-images.githubusercontent.com/72426535/121448327-0e3bdd80-c9b5-11eb-80e6-1c5a91995ffa.png)
</b> |
