### PR TITLE
Bugs fixed in roots of equation 

### DIFF
--- a/calculators/rootsOfEquation.html
+++ b/calculators/rootsOfEquation.html
@@ -8,7 +8,7 @@
                 <div class="modal-dialog" role="document">
                     <div class="modal-content">
                         <div class="modal-header">
-                            <h5 class="modal-title" style="color:white;">Rules for Roots of Quadratic
+                            <h5 class="modal-title" style="color:black !important;">Rules for Roots of Quadratic
                                 Equation</h5>
                             <button type="button" class="close" data-dismiss="modal" aria-label="Close"
                                 style="outline: none;">
@@ -16,9 +16,9 @@
                             </button>
                         </div>
                         <div class="modal-body">
-                            <p>There are no Real Roots if \[b^2-4ac0\]</p>
-                                    <p>There is one Real Root if \[b^2-4ac=0\]</p>
-                                    <p>There are two Real Roots if \[b^2-4ac>0\]</p>
+                            <p>There are no Real Roots if \[b^2-4ac<0\]</p>
+                            <p>There are two Equal Real Roots if \[b^2-4ac=0\]</p>
+                            <p>There are two Real Roots if \[b^2-4ac>0\]</p>
                         </div>
                         <div class="modal-footer">
                             <button type="button" class="btn btn-secondary" data-dismiss="modal">Close
@@ -60,12 +60,12 @@
         </div>
     </div>
     <h4>Nature of the roots of the Quadratic Equation ax<sup>2</sup> + bx + c, a ≠ 0, a, b, c ∈ R</h4>
-    <p>To find out the nature of the roots of a quadratic equation,</p>
+    <p>To find out the nature of the roots of a quadratic equation, we find the value of the discriminant D \[D=b^2-4ac\]</p>
     <ol>
-        <li style="color: white; font-size: 1.25rem;">We find the value of the discriminant D. If D < 0, we
+        <li style="color: white; font-size: 1.25rem;">If D < 0, we
                 immediately say that equation has no solution in R.</li>
                 <br>
-        <li style="color: white; font-size: 1.25rem;">If D ≥ 0, then we examine whether it is a perfect
+        <li style="color: white; font-size: 1.25rem;">If D > 0, then we examine whether it is a perfect
             square of a rational number or not.
             <ol type="i">
                 <li style="color: white; font-size: 1.25rem;">If D > 0 and D is not a perfect square, then

--- a/calculators/rootsOfEquation.html
+++ b/calculators/rootsOfEquation.html
@@ -9,7 +9,7 @@
                     <div class="modal-content">
                         <div class="modal-header">
                             <h5 class="modal-title" style="color:black !important;">Rules for Roots of Quadratic
-                                Equation</h5>
+                                Equation </h5>
                             <button type="button" class="close" data-dismiss="modal" aria-label="Close"
                                 style="outline: none;">
                                 <span aria-hidden="true">&times;</span>


### PR DESCRIPTION
## Related Issue
https://github.com/makesmatheasy/makesmatheasy/issues/5315#issue-929592583


In Equation ---> Roots of Equation
Issues:

Below
Nature of roots, at the 2nd point it should be only '>' instead of '>='.
In rules section, the colour of heading should be darker as it is not much visible.
In rules section, In the first rule there is a '<' sign missing.
In rules section, Second rule- more appropriate statement can be used i.e
instead of 'There is one real root if' we can write 'There are two equal real roots if'
I would like to work on this issue.

fix #5315 

#### All above issues are solved. 
Additionaly, I also made changes in heading below the "Roots " title.


- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| **![original1](https://user-images.githubusercontent.com/64557006/123422201-7a385b80-d5db-11eb-8faa-c44daeb5d150.png)** | <b>![Final1](https://user-images.githubusercontent.com/64557006/123422226-86241d80-d5db-11eb-971a-0f5936fa6cb0.png)</b> |
| :---------------------: | :------------------------: |
| **![original2](https://user-images.githubusercontent.com/64557006/123422259-93410c80-d5db-11eb-82e8-f9388bd199f3.png)** | <b>![Final2](https://user-images.githubusercontent.com/64557006/123422296-9d630b00-d5db-11eb-9228-80bf31e49710.png)</b> |



