### PR TITLE
Resolved the issue that half life calculator keeps showing

### DIFF
--- a/appdata/menudata/generalMaths.html
+++ b/appdata/menudata/generalMaths.html
@@ -201,7 +201,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Direct And Indirect Propoertion</span>
+              <span class="caltext" onclick="loadcalculator('calculators/directAndIndirectProportion.html','directAndIndirectProportion')">Direct And Indirect Proportion</span>
           </div>
       </div>
 
@@ -209,7 +209,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Cross Multiplication Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/crossMultiplcationCalculator.html','crossMultiplicationCalculator')">Cross Multiplication Calculator</span>
           </div>
       </div>
 
@@ -217,7 +217,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Diamond Problem Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/diamondProblemCalculator.html','diamondProblemCalculator')">Diamond Problem Calculator</span>
           </div>
       </div>
 
@@ -225,7 +225,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Additive Inverse</span>
+              <span class="caltext" onclick="loadcalculator('calculators/additiveInverse.html','additiveInverse')">Additive Inverse</span>
           </div>
       </div>
 
@@ -233,7 +233,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Multiplicative Inverse</span>
+              <span class="caltext" onclick="loadcalculator('calculators/multiplicativeInverse.html','multiplicativeInverse')">Multiplicative Inverse</span>
           </div>
       </div>
 
@@ -241,7 +241,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Square Root Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/squareRootCalculator.html','squareRootCalculator')">Square Root Calculator</span>
           </div>
       </div>
 
@@ -249,7 +249,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Unit Rate Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/unitRateCalculator.html','unitRateCalculator')">Unit Rate Calculator</span>
           </div>
       </div>
 
@@ -257,7 +257,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Order Of Magnitude Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/orderOfMagnitudeCalculator.html','orderOfMagnitudeCalculator')">Order Of Magnitude Calculator</span>
           </div>
       </div>
 
@@ -265,7 +265,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Work And Time Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/workAndTimeCalculator.html','workAndTimeCalculator')">Work And Time Calculator</span>
           </div>
       </div>
 
@@ -273,7 +273,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Kaprekar Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/kaprekarNumber.html','kaprekarNumber')">Kaprekar Number</span>
           </div>
       </div>
 
@@ -281,7 +281,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Wagstaff Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/wagstaffNumber.html','wagstaffNumber')">Wagstaff Number</span>
           </div>
       </div>
 
@@ -289,7 +289,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Abundant Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/abundantNumber.html','abundantNumber')">Abundant Number</span>
           </div>
       </div>
 
@@ -297,7 +297,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Woodall Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/woodallNumber.html','woodallNumber')">Woodall Number</span>
           </div>
       </div>
 
@@ -305,7 +305,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Hyperperfect Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/hyperperfectNumber.html','hyperperfectNumber')">Hyperperfect Number</span>
           </div>
       </div>
 
@@ -313,7 +313,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Solve For Exponents</span>
+              <span class="caltext" onclick="loadcalculator('calculators/solveForExponents.html','solveForExponents')">Solve For Exponents</span>
           </div>
       </div>
 
@@ -321,7 +321,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Sum Of Square Of Given Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/sumOfSquaresCalculator.html','sumOfSquaresCalculator')">Sum Of Square Of Given Number</span>
           </div>
       </div>
 
@@ -329,7 +329,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Binomial Distribution PMF</span>
+              <span class="caltext" onclick="loadcalculator('calculators/binomialDistributionPmf.html','binomialDistributionPmf')">Binomial Distribution PMF</span>
           </div>
       </div>
 
@@ -337,7 +337,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Natural Numbers</span>
+              <span class="caltext" onclick="loadcalculator('calculators/naturalNumbers.html','naturalNumbers')">Natural Numbers</span>
           </div>
       </div>
 
@@ -345,7 +345,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Clock Angle Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/clockAngleCalculator.html','clockAngleCalculator')">Clock Angle Calculator</span>
           </div>
       </div>
 
@@ -353,14 +353,14 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Root Mean Square</span>
+              <span class="caltext" onclick="loadcalculator('calculators/rootMeanSquare.html','rootMeanSquare')">Root Mean Square</span>
           </div>
       </div>
 
       <div class="col-md-3 col-6">
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
-
+                <!--Squares and Cubes Calculator cannot be found!-->
               <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Squares And Cubes Calculator</span>
           </div>
       </div>
@@ -369,7 +369,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">n-th Base Root Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/nthbaserootcalculator.html','nthbaserootcalculator')">n-th Base Root Calculator</span>
           </div>
       </div>
 
@@ -377,7 +377,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Perfect Squares And Cubes In a Range</span>
+              <span class="caltext" onclick="loadcalculator('calculators/perfectSquaresCubesRange.html','perfectSquaresCubesRange')">Perfect Squares And Cubes In a Range</span>
           </div>
       </div>
 
@@ -385,7 +385,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Factorization</span>
+              <span class="caltext" onclick="loadcalculator('calculators/factorization.html','factorization')">Factorization</span>
           </div>
       </div>
 
@@ -393,7 +393,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Percentage Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/percentageCalculator.html','percentageCalculator')">Percentage Calculator</span>
           </div>
       </div>
 
@@ -401,7 +401,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Error Percentage Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/errorPercentageCalculator.html','errorPercentageCalculator')">Error Percentage Calculator</span>
           </div>
       </div>
 
@@ -409,7 +409,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Interest(Simple,Compound)</span>
+              <span class="caltext" onclick="loadcalculator('calculators/interestSimpleCompound.html','interestSimpleCompound')">Interest(Simple,Compound)</span>
           </div>
       </div>
 
@@ -417,7 +417,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Cost And Selling Prices</span>
+              <span class="caltext" onclick="loadcalculator('calculators/costAndSellingPrices.html','costAndSellingPrices')">Cost And Selling Prices</span>
           </div>
       </div>
 
@@ -425,7 +425,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Effective Interest Rate</span>
+              <span class="caltext" onclick="loadcalculator('calculators/effectiveInterestRate.html','effectiveInterestRate')">Effective Interest Rate</span>
           </div>
       </div>
 
@@ -433,7 +433,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Profit Loss Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/profitLossCalculations.html','profitLossCalculations')">Profit Loss Calculator</span>
           </div>
       </div>
 
@@ -441,7 +441,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Set Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/setCalculator.html','setCalculator')">Set Calculator</span>
           </div>
       </div>
 
@@ -449,7 +449,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Pythagorean Triplets</span>
+              <span class="caltext" onclick="loadcalculator('calculators/pythagoreanTriplets.html','pythagoreanTriplets')">Pythagorean Triplets</span>
           </div>
       </div>
 
@@ -457,7 +457,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Rank Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/rankCalculator.html','rankCalculator')">Rank Calculator</span>
           </div>
       </div>
 
@@ -465,7 +465,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Leap Year</span>
+              <span class="caltext" onclick="loadcalculator('calculators/leapYear.html','leapYear')">Leap Year</span>
           </div>
       </div>
 
@@ -473,7 +473,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Hydrostatic Pressure</span>
+              <span class="caltext" onclick="loadcalculator('calculators/hydrostaticPressure.html','hydrostaticPressure')">Hydrostatic Pressure</span>
           </div>
       </div>
 
@@ -481,7 +481,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Logarithm Properties</span>
+              <span class="caltext" onclick="loadcalculator('study/logarithmProperties.html','logarithmProperties')">Logarithm Properties</span>
           </div>
       </div>
 
@@ -489,7 +489,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Logariythm Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/logarithmCalculator.html','logarithmCalculator')">Logarithm Calculator</span>
           </div>
       </div>
 
@@ -497,7 +497,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Ln Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/lnCalculator.html','lnCalculator')">Ln Calculator</span>
           </div>
       </div>
 
@@ -505,7 +505,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Binomial Theorem Properties</span>
+              <span class="caltext" onclick="loadcalculator('study/binomialTheoremProperties.html','binomialTheoremProperties')">Binomial Theorem Properties</span>
           </div>
       </div>
 
@@ -513,7 +513,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Binomial Coefficient Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/binomialCoefficientCalculator.html','binomialCoefficientCalculator')">Binomial Coefficient Calculator</span>
           </div>
       </div>
 
@@ -521,7 +521,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Binomial Expression Multiplication</span>
+              <span class="caltext" onclick="loadcalculator('calculators/binomialExpressionMultiplication.html','binomialExpressionMultiplication')">Binomial Expression Multiplication</span>
           </div>
       </div>
 
@@ -529,7 +529,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Foil Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/foilCalculator.html','foilCalculator')">Foil Calculator</span>
           </div>
       </div>
 
@@ -537,7 +537,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Operations On Fractions</span>
+              <span class="caltext" onclick="loadcalculator('calculators/operationsOnFractions.html','operationsOnFractions')">Operations On Fractions</span>
           </div>
       </div>
 
@@ -545,7 +545,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Solve Fraction</span>
+              <span class="caltext" onclick="loadcalculator('calculators/solveFraction.html','solveFraction')">Solve Fraction</span>
           </div>
       </div>
 
@@ -553,7 +553,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Multiplication Table</span>
+              <span class="caltext" onclick="loadcalculator('calculators/multiplicationTable.html','multiplicationTable')">Multiplication Table</span>
           </div>
       </div>
 
@@ -561,7 +561,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Divide</span>
+              <span class="caltext" onclick="loadcalculator('calculators/divide.html','divide')">Divide</span>
           </div>
       </div>
 
@@ -569,7 +569,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Multiply With Steps</span>
+              <span class="caltext" onclick="loadcalculator('calculators/multiplyWithSteps.html','multiplyWithSteps')">Multiply With Steps</span>
           </div>
       </div>
 
@@ -577,7 +577,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Round Off</span>
+              <span class="caltext" onclick="loadcalculator('calculators/roundoff.html','roundoff')">Round Off</span>
           </div>
       </div>
 
@@ -585,7 +585,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Convolution Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/convolution.html','convolution')">Convolution Calculator</span>
           </div>
       </div>
 
@@ -593,7 +593,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">E.M.I. Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/emiCalculator.html','emiCalculator')">E.M.I. Calculator</span>
           </div>
       </div>
 
@@ -601,7 +601,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">G.S.T. Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/gstCalculator.html','gstCalculator')">G.S.T. Calculator</span>
           </div>
       </div>
 
@@ -609,7 +609,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Golden Ratio Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/goldenRatioCalculator.html','goldenRatioCalculator')">Golden Ratio Calculator</span>
           </div>
       </div>
 
@@ -617,7 +617,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Golden Rectangle Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/goldenRectangleCalculator.html','goldenRectangleCalculator')">Golden Rectangle Calculator</span>
           </div>
       </div>
 
@@ -625,7 +625,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Polynomial Degree</span>
+              <span class="caltext" onclick="loadcalculator('calculators/polynomialDegree.html','polynomialDegree')">Polynomial Degree</span>
           </div>
       </div>
 
@@ -633,7 +633,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Factorial</span>
+              <span class="caltext" onclick="loadcalculator('calculators/factorial.html','factorial')">Factorial</span>
           </div>
       </div>
 
@@ -641,7 +641,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Permutation And Combination</span>
+              <span class="caltext" onclick="loadcalculator('calculators/permutationAndCombination.html','permutationAndCombination')">Permutation And Combination</span>
           </div>
       </div>
 
@@ -649,7 +649,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Speed Distance Time Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/speedDistanceTimeCalculator.html','speedDistanceTimeCalculator')">Speed Distance Time Calculator</span>
           </div>
       </div>
 
@@ -657,7 +657,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Prime Numbers</span>
+              <span class="caltext" onclick="loadcalculator('calculators/primeNumbers.html','primeNumbers')">Prime Numbers</span>
           </div>
       </div>
 
@@ -665,7 +665,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Co-Prime Calculator </span>
+              <span class="caltext" onclick="loadcalculator('calculators/coprimeCalculator.html','coprimeCalculator')">Co-Prime Calculator </span>
           </div>
       </div>
 
@@ -673,7 +673,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">C0-Prime Numbers Theory</span>
+              <span class="caltext" onclick="loadcalculator('study/coprimeNumbersTheory.html','coprimeNumbersTheory')">Co-Prime Numbers Theory</span>
           </div>
       </div>
 
@@ -681,7 +681,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Euler Totient Function</span>
+              <span class="caltext" onclick="loadcalculator('calculators/eulerTotientFunction.html','eulerTotientFunction')">Euler Totient Function</span>
           </div>
       </div>
 
@@ -689,7 +689,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Eulent Totient Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/eulerTotientCalculator.html','eulerTotientCalculator')">Eulent Totient Calculator</span>
           </div>
       </div>
 
@@ -697,7 +697,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Next Prime Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/nextPrimeNumber.html','nextPrimeNumber')">Next Prime Number</span>
           </div>
       </div>
 
@@ -705,7 +705,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Smallest Prime Factor</span>
+              <span class="caltext" onclick="loadcalculator('calculators/smallestPrimeFactor.html','smallestPrimeFactor')">Smallest Prime Factor</span>
           </div>
       </div>
 
@@ -713,7 +713,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Sum Of Divisors</span>
+              <span class="caltext" onclick="loadcalculator('calculators/sumOfDivisors.html','sumOfDivisors')">Sum Of Divisors</span>
           </div>
       </div>
 
@@ -721,7 +721,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Double Factorial</span>
+              <span class="caltext" onclick="loadcalculator('calculators/doubleFactorial.html','doubleFactorial')">Double Factorial</span>
           </div>
       </div>
 
@@ -729,7 +729,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Catalan Numbers Calculator</span>
+              <span class="caltext" onclick="loadcalculator('calculators/catalanNumber.html','catalanNumber')">Catalan Numbers Calculator</span>
           </div>
       </div>
 
@@ -737,15 +737,15 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Special number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/specialNumber.html','specialNumber')">Special number</span>
           </div>
       </div>
 
       <div class="col-md-3 col-6">
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
-
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Desargues Theorem</span>
+                <!--Desargues Theorem cannot be found!-->
+              <span class="caltext" onclick="loadcalculator('study/desarguesTheorem.html','desarguesTheorem')">Desargues Theorem</span>
           </div>
       </div>
 
@@ -753,7 +753,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Dirichlet's theorem on arithmetic progressions</span>
+              <span class="caltext" onclick="loadcalculator('calculators/dirichletTheoremOnArithmeticProgressions.html','dirichletTheoremOnArithmeticProgressions')">Dirichlet's theorem on arithmetic progressions</span>
           </div>
       </div>
 
@@ -761,7 +761,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Smallest Number Divisible</span>
+              <span class="caltext" onclick="loadcalculator('calculators/smallestNumberDivisible.html','smallestNumberDivisible')">Smallest Number Divisible</span>
           </div>
       </div>
 
@@ -769,7 +769,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Lucas Series</span>
+              <span class="caltext" onclick="loadcalculator('calculators/lucasSeries.html','lucasSeries')">Lucas Series</span>
           </div>
       </div>
 
@@ -777,7 +777,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Types Of Numbers</span>
+              <span class="caltext" onclick="loadcalculator('calculators/typesOfNumbers.html','typesOfNumbers')">Types Of Numbers</span>
           </div>
       </div>
 
@@ -785,7 +785,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Duck Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/duckNumber.html','duckNumber')">Duck Number</span>
           </div>
       </div>
 
@@ -793,7 +793,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Armstrong Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/armstrongNumber.html','armstrongNumber')">Armstrong Number</span>
           </div>
       </div>
 
@@ -801,7 +801,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Pallindrome Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/palindromeNumber.html','palindromeNumber')">Palindrome Number</span>
           </div>
       </div>
 
@@ -809,7 +809,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Perfect Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/perfectNumber.html','perfectNumber')">Perfect Number</span>
           </div>
       </div>
 
@@ -817,7 +817,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Emrip Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/emripNumber.html','emripNumber')">Emrip Number</span>
           </div>
       </div>
 
@@ -825,7 +825,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Neon Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/neonNumber.html','neonNumber')">Neon Number</span>
           </div>
       </div>
 
@@ -833,7 +833,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Disarium Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/disariumNumber.html','disariumNumber')">Disarium Number</span>
           </div>
       </div>
 
@@ -841,7 +841,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Happy Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/happyNumber.html','happyNumber')">Happy Number</span>
           </div>
       </div>
 
@@ -849,7 +849,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Krishnamurthy Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/krishnamurthyNumber.html','krishnamurthyNumber')">Krishnamurthy Number</span>
           </div>
       </div>
 
@@ -857,7 +857,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Automorphic Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/automorphicNumber.html','automorphicNumber')">Automorphic Number</span>
           </div>
       </div>
 
@@ -865,7 +865,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Magic Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/magicNumber.html','magicNumber')">Magic Number</span>
           </div>
       </div>
 
@@ -873,7 +873,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Pronic Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/pronicNumber.html','pronicNumber')">Pronic Number</span>
           </div>
       </div>
 
@@ -881,7 +881,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Harshad Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/harshadNumber.html','harshadNumber')">Harshad Number</span>
           </div>
       </div>
 
@@ -889,7 +889,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Trimorphic Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/trimorphicNumber.html','trimorphicNumber')">Trimorphic Number</span>
           </div>
       </div>
 
@@ -897,7 +897,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Amicable Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/amicable.html','amicable')">Amicable Number</span>
           </div>
       </div>
 
@@ -905,7 +905,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Eulerian Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/eulerianNumber.html','eulerianNumber')">Eulerian Number</span>
           </div>
       </div>
 
@@ -913,7 +913,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Carmichael Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/carmichaelNumber.html','carmichaelNumber')">Carmichael Number</span>
           </div>
       </div>
 
@@ -921,7 +921,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Delannoy Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/delannoyNumber.html','delannoyNumber')">Delannoy Number</span>
           </div>
       </div>
 
@@ -929,7 +929,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Cullen Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/cullenNumber.html','cullenNumber')">Cullen Number</span>
           </div>
       </div>
 
@@ -937,7 +937,7 @@
           <div class="option">
               <img id="statsimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
 
-              <span class="caltext" onclick="loadcalculator('calculators/halfLifeCalculator.html','halfLifeCalculator')">Pell Number</span>
+              <span class="caltext" onclick="loadcalculator('calculators/pellNumber.html','pellNumber')">Pell Number</span>
           </div>
       </div>
     </div>


### PR DESCRIPTION
## Related Issue

- Info about Issue or bug

fix #5384  

#### Describe the changes you've made

Rewrote the app logic in appdata/menudata/generalMaths.html
Previously, someone left the code "half done" which results in most calculators (around 80% of the calculator in generalMaths.html) have false logic that redirect users to Half Life Calculator.

After rewriting app logic:
Now all calculators in generalMaths.html can redirect to their relevant calculator page.

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| ![image](https://user-images.githubusercontent.com/86700378/126283304-fbae97ef-1eb9-4c14-af6e-62d6d0ded84e.png) | <b>![image](https://user-images.githubusercontent.com/86700378/126283257-8a7c6a71-d751-4e6a-a041-e1919233de06.png) </b> |
