### PR TITLE
Make `nav` stay on top

### DIFF
--- a/index.html
+++ b/index.html
@@ -271,7 +271,9 @@
         function openOption(path, displayname) {
             $("#mainsection").hide().load(path, function (response, status, xhttp) {
                 if (xhttp.status == 200) {
-
+                    $("nav").parent().css('z-index', 1e5);
+                    $("nav").css('z-index', 1e5);
+                    $(".uppernav").css('z-index', 1e6)
                 }
             }).fadeIn('1000');
             document.getElementById('maintext').innerHTML = displayname;


### PR DESCRIPTION
#### Describe the changes you've made

Make the `nav` tag to always stay on top (and the `uppernav` class on top of it)

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.

## Screenshots

|        Original         |          Updated           |
| :---------------------: | :------------------------: |
| ![image](https://user-images.githubusercontent.com/61805754/134814137-99feb1af-9fac-4697-b9d8-8eeefd53bbff.png) | <b>![image](https://user-images.githubusercontent.com/61805754/134814122-5342791f-c002-4ecf-9b8a-48102b07c28b.png) </b> |
