### PR TITLE
Remove `areaOfCrescentAndLune`

### DIFF
--- a/appdata/menudata/graphsShapes.html
+++ b/appdata/menudata/graphsShapes.html
@@ -228,7 +228,7 @@
             <div class="option">
                 <img id="crescimgfav" src="icons/unfavourite.png" alt="" onclick="addtofavourites(this)">
                 
-                <span class="caltext" onclick="loadcalculator('calculators/areaOfCrescentAndLune.html','Area of Crescent and Lune')">
+                <span class="caltext" onclick="loadcalculator('calculators/areaOfCrescentandLune.html','Area of Crescent and Lune')">
                     Area of Crescent and Lune</span>
             </div>
         </div>

--- a/calculators/areaOfCrescentAndLune.html
+++ b/calculators/areaOfCrescentAndLune.html
@@ -1,3 +1,16 @@
+<div class="back" onclick="openOption('appdata/menudata/graphsShapes.html','Graph and Spaces')">
+    <img
+        style="       
+            background-color: whitesmoke;
+            margin-bottom: 10px;
+            margin-left: 10px;
+            margin-top: 10px;
+            display: block !important;
+            height: 30px;
+            box-shadow: 0 0 10px white;
+            border-radius: 50%;
+            padding:5px;
+        " src="./icons/back.png" alt=""></div>
 <div id="crescentLune">
     <h1 style="font-family:mathfont; text-align:center;">AREA OF CRESCENT AND LUNE</h1>
     <form action="">


### PR DESCRIPTION
## Related Issue

fix #5420

#### Describe the changes you've made

`areaOfCrescentAndLune` appears just in [graphsShapes.html](https://github.com/makesmatheasy/makesmatheasy/blob/main/appdata/menudata/graphsShapes.html) here:
https://github.com/makesmatheasy/makesmatheasy/blob/c56ad9660cc06498e7b983e610eb9a576c39659e/appdata/menudata/graphsShapes.html#L231
though `areaOfCrescentandLune` looks more updated, I'll remove the old one and point `graphsShapes` towards the new one

_Originally posted in https://github.com/makesmatheasy/makesmatheasy/issues/5420#issuecomment-932048011_

## Checklist:

- [x] My code follows the style guidelines of this project.
- [x] I have performed a self-review of my own code.
