### PR TITLE
Backward Button added successfully in required pages of Trigonometry

### DIFF
--- a/calculators/distanceBetweenIncenterAndExcenter.html
+++ b/calculators/distanceBetweenIncenterAndExcenter.html
@@ -1,12 +1,22 @@
+<div class="back" onclick="openOption('appdata/menudata/trigonometry.html','Trigonometry')">
+    <img style="       
+            background-color: whitesmoke;
+            margin-bottom: 10px;
+            margin-left: 10px;
+            margin-top: 10px;
+            display: block !important;
+            height: 30px;
+            box-shadow: 0 0 10px white;
+            border-radius: 50%;
+            padding:5px;
+        " src="./icons/back.png" alt=""></div>
 <div id="incenterexcenter">
     <h2>Distance between Incenter and Excenter of a Triangle</h2><br>
     <p id="incenex">\[4RsinA/2\]</p>
     <form action="">
         <div class="form-group">
-            <input type="text" style="width: 250px;" class="form__field" name="a" id="ex_rad"
-                placeholder="Enter External radius" />
-            <input type="text" name="b" style="width: 250px;" class="form__field" id="angle_1"
-                placeholder="Enter angle A " /> <br> <br>
+            <input type="text" style="width: 250px;" class="form__field" name="a" id="ex_rad" placeholder="Enter External radius" />
+            <input type="text" name="b" style="width: 250px;" class="form__field" id="angle_1" placeholder="Enter angle A " /> <br> <br>
             <button class="btn btn-outline-light" type="button" onclick="dist_incenex()">Find</button>
             <button class="btn btn-outline-light" type="button" onclick="this.form.reset();">Reset</button>
             <br>

--- a/study/generalSolutionOfTrigonometryEquation.html
+++ b/study/generalSolutionOfTrigonometryEquation.html
@@ -1,40 +1,35 @@
+<div class="back" onclick="openOption('appdata/menudata/trigonometry.html','Trigonometry')">
+    <img style="       
+            background-color: whitesmoke;
+            margin-bottom: 10px;
+            margin-left: 10px;
+            margin-top: 10px;
+            display: block !important;
+            height: 30px;
+            box-shadow: 0 0 10px white;
+            border-radius: 50%;
+            padding:5px;
+        " src="./icons/back.png" alt=""></div>
 <div class="stopwrap">
     <div class="coll">
         <div class="left">
             <h4>General Solution of Some Trigonometric Equations</h4>
-            <p>\[1)\space If \space sin\theta=0, \space then \space \theta=n\pi,
-                \space n \in I(set \space of \space integers)\]</p>
-            <p>\[2)\space If \space cos\theta=0, \space then \space
-                \theta=(2n+1)\frac{\pi}{2}, \space n \in I\]</p>
-            <p>\[3)\space If \space tan\theta=0, \space then \space \theta=n\pi,
-                \space n \in I\]</p>
-            <p>\[4)\space If \space sin\theta=sin\alpha, \space then \space
-                \theta=n\pi +(-1)^n\alpha, \space where \space \alpha \in
-                [\frac{-\pi}{2},\frac{\pi}{2}], \space n\in I\]</p>
-            <p>\[5)\space If \space cos\theta=cos\alpha, \space then \space
-                \theta=2n\pi ± \alpha, \space n \in I \space \alpha \in
-                [0,\pi]\]</p>
-            <p>\[6)\space If \space tan\theta=tan\alpha, \space then \space
-                \theta=n\pi + \alpha, \space n \in I \space \alpha \in
-                (\frac{-\pi}{2},\frac{\pi}{2})\]</p>
-            <p>\[7)\space If \space sin\theta=1, \space \theta=2n\pi+
-                \frac{\pi}{2}=(4n+1)\frac{\pi}{2}, \space n \in I\]</p>
-            <p>\[8)\space If \space cos\theta=1 \space then \space \theta=2n\pi,
-                \space n \in I\]</p>
-            <p>\[9)\space If sin^2\theta \space =sin^2\alpha \space \space or \space
-                cos^2\theta \space = cos^2\alpha \space \space or \space tan^2\theta
-                \space = tan^2\alpha,\]\[then \space \theta=n\pi \space ± \space
-                \alpha, \space n \in I\]</p>
-            <p>\[10)\space For \space n \in I, \space sinn\pi=0 \space and \space
-                cosn\pi \space =(-1)^n, \space n \in I \]\[sin(n\pi + \theta) \space
-                = (-1)^nsin\theta\]\[cos(n\pi+ \theta) \space =(-1)^ncos\theta\]</p>
+            <p>\[1)\space If \space sin\theta=0, \space then \space \theta=n\pi, \space n \in I(set \space of \space integers)\]</p>
+            <p>\[2)\space If \space cos\theta=0, \space then \space \theta=(2n+1)\frac{\pi}{2}, \space n \in I\]</p>
+            <p>\[3)\space If \space tan\theta=0, \space then \space \theta=n\pi, \space n \in I\]</p>
+            <p>\[4)\space If \space sin\theta=sin\alpha, \space then \space \theta=n\pi +(-1)^n\alpha, \space where \space \alpha \in [\frac{-\pi}{2},\frac{\pi}{2}], \space n\in I\]</p>
+            <p>\[5)\space If \space cos\theta=cos\alpha, \space then \space \theta=2n\pi ± \alpha, \space n \in I \space \alpha \in [0,\pi]\]
+            </p>
+            <p>\[6)\space If \space tan\theta=tan\alpha, \space then \space \theta=n\pi + \alpha, \space n \in I \space \alpha \in (\frac{-\pi}{2},\frac{\pi}{2})\]
+            </p>
+            <p>\[7)\space If \space sin\theta=1, \space \theta=2n\pi+ \frac{\pi}{2}=(4n+1)\frac{\pi}{2}, \space n \in I\]</p>
+            <p>\[8)\space If \space cos\theta=1 \space then \space \theta=2n\pi, \space n \in I\]</p>
+            <p>\[9)\space If sin^2\theta \space =sin^2\alpha \space \space or \space cos^2\theta \space = cos^2\alpha \space \space or \space tan^2\theta \space = tan^2\alpha,\]\[then \space \theta=n\pi \space ± \space \alpha, \space n \in I\]</p>
+            <p>\[10)\space For \space n \in I, \space sinn\pi=0 \space and \space cosn\pi \space =(-1)^n, \space n \in I \]\[sin(n\pi + \theta) \space = (-1)^nsin\theta\]\[cos(n\pi+ \theta) \space =(-1)^ncos\theta\]</p>
             <p>\[11)\space cos \space n\pi \space = (-1)^n, \space n \in I\]</p>
-            <p>\[12)\space If \space n \space is \space an \space odd \space integer
-                \space then \space sin\frac{n\pi}{2}=(-1)^{\frac{n-1}{2}}, \space
-                cos\frac{n\pi}{2}=0\]</p>
-            <p>\[13)\space sin(\frac{n\pi}{2}+\theta) \space = (-1)^{\frac{n-1}{2}}
-                \space cos\theta, \space cos(\frac{n\pi}{2}+\theta) \space =
-                (-1)^{\frac{n+1}{2}}sin\theta\]
+            <p>\[12)\space If \space n \space is \space an \space odd \space integer \space then \space sin\frac{n\pi}{2}=(-1)^{\frac{n-1}{2}}, \space cos\frac{n\pi}{2}=0\]
+            </p>
+            <p>\[13)\space sin(\frac{n\pi}{2}+\theta) \space = (-1)^{\frac{n-1}{2}} \space cos\theta, \space cos(\frac{n\pi}{2}+\theta) \space = (-1)^{\frac{n+1}{2}}sin\theta\]
         </div>
     </div>
 </div>

--- a/study/hyperbolicIdentities.html
+++ b/study/hyperbolicIdentities.html
@@ -1,30 +1,35 @@
+<div class="back" onclick="openOption('appdata/menudata/trigonometry.html','Trigonometry')">
+    <img style="       
+            background-color: whitesmoke;
+            margin-bottom: 10px;
+            margin-left: 10px;
+            margin-top: 10px;
+            display: block !important;
+            height: 30px;
+            box-shadow: 0 0 10px white;
+            border-radius: 50%;
+            padding:5px;
+        " src="./icons/back.png" alt=""></div>
 <h2 style="text-align: center; margin-bottom:20px;">Hyperbolic Trigonometric Identities</h2>
-<p style="color:#d3d3d3;margin-bottom: 5px;">The hyperbolic functions are analogs of the circular
-    function or the trigonometric functions. The hyperbolic function occurs in the solutions of linear
-    differential equations, calculation of distance and angles in the hyperbolic geometry, Laplace’s
-    equations in the cartesian coordinates. Generally, the hyperbolic function takes place in the real
-    argument called the hyperbolic angle. The basic hyperbolic functions are:</p>
+<p style="color:#d3d3d3;margin-bottom: 5px;">The hyperbolic functions are analogs of the circular function or the trigonometric functions. The hyperbolic function occurs in the solutions of linear differential equations, calculation of distance and angles in the hyperbolic geometry, Laplace’s equations
+    in the cartesian coordinates. Generally, the hyperbolic function takes place in the real argument called the hyperbolic angle. The basic hyperbolic functions are:</p>
 <br>
 <ul>
-    <li style="color:#ababab; font-size: 1.25rem; text-align: center; list-style:none;">1 Hyperbolic
-        Sine(sinh)</li>
-    <li style="color:#ababab; font-size: 1.25rem; text-align: center; list-style:none;">2 Hyperbolic
-        Cosine(cosh)</li>
-    <li style="color:#ababab; font-size: 1.25rem; text-align: center; list-style:none;">3 Hyperbolic
-        Tangent(tanh)</li>
+    <li style="color:#ababab; font-size: 1.25rem; text-align: center; list-style:none;">1 Hyperbolic Sine(sinh)
+    </li>
+    <li style="color:#ababab; font-size: 1.25rem; text-align: center; list-style:none;">2 Hyperbolic Cosine(cosh)
+    </li>
+    <li style="color:#ababab; font-size: 1.25rem; text-align: center; list-style:none;">3 Hyperbolic Tangent(tanh)
+    </li>
 </ul>
-<p style="color:#ababab; ">From these three basic functions, the other functions such as hyperbolic
-    cosecant (cosech), hyperbolic secant(sech) and hyperbolic cotangent (coth) functions are derived.
+<p style="color:#ababab; ">From these three basic functions, the other functions such as hyperbolic cosecant (cosech), hyperbolic secant(sech) and hyperbolic cotangent (coth) functions are derived.
 </p>
 <p style="color:#d3d3d3;">\[sinh(x)\space =\space \frac{e^{x}-e^{-x}}{2}\]</p>
-<img style="margin-left:auto;margin-right:auto;width:50%;display:block"
-    src="https://cdn1.byjus.com/wp-content/uploads/2019/09/Hyperbolic-functions-1.png" class="img-fluid mx-auto" alt="">
+<img style="margin-left:auto;margin-right:auto;width:50%;display:block" src="https://cdn1.byjus.com/wp-content/uploads/2019/09/Hyperbolic-functions-1.png" class="img-fluid mx-auto" alt="">
 <p style="color:#d3d3d3;">\[cosh(x)\space =\space \frac{e^{x}+e^{-x}}{2}\]</p>
-<img style="margin-left:auto;margin-right:auto;width:50%;display:block"
-    src="https://cdn1.byjus.com/wp-content/uploads/2019/09/Hyperbolic-functions-2.png" class="img-fluid mx-auto" alt="">
+<img style="margin-left:auto;margin-right:auto;width:50%;display:block" src="https://cdn1.byjus.com/wp-content/uploads/2019/09/Hyperbolic-functions-2.png" class="img-fluid mx-auto" alt="">
 <p style="color:#d3d3d3;">\[tanh(x)\space =\space \frac{e^{x}-e^{-x}}{e^{x}+e^{-x}}\]</p>
-<img style="margin-left:auto;margin-right:auto;width:50%;display:block"
-    src="https://cdn1.byjus.com/wp-content/uploads/2019/09/Hyperbolic-functions-3.png" class="img-fluid mx-auto" alt="">
+<img style="margin-left:auto;margin-right:auto;width:50%;display:block" src="https://cdn1.byjus.com/wp-content/uploads/2019/09/Hyperbolic-functions-3.png" class="img-fluid mx-auto" alt="">
 <h4 style="text-align: center; margin-top:18px;">Properties of Hyperbolic Functions</h4>
 <p style="color:#d3d3d3;">\[sinh(-x)\space =\space -sinh(x)\]</p>
 <p style="color:#d3d3d3;">\[cosh(-x)\space =\space cosh(x)\]</p>

--- a/study/inverseHyperbolicIdentities.html
+++ b/study/inverseHyperbolicIdentities.html
@@ -1,10 +1,18 @@
+<div class="back" onclick="openOption('appdata/menudata/trigonometry.html','Trigonometry')">
+    <img style="       
+            background-color: whitesmoke;
+            margin-bottom: 10px;
+            margin-left: 10px;
+            margin-top: 10px;
+            display: block !important;
+            height: 30px;
+            box-shadow: 0 0 10px white;
+            border-radius: 50%;
+            padding:5px;
+        " src="./icons/back.png" alt=""></div>
 <h2 style="text-align: center;">Inverse Hyperbolic Trigonometric Identities</h2>
-<p style="text-align: center; color: #ababab !important;">The hyperbolic sine function is a one-to-one
-    function and thus has an inverse. As usual, the graph of the inverse hyperbolic sine function
-    sinh<sup>-1</sup>(x) also denoted by arcsinh(x) by reflecting the graph of sinh(x) about the line
-    y=x
-    For all inverse hyperbolic functions but the inverse hyperbolic cotangent and the inverse hyperbolic
-    cosecant, the domain of the real function is connected.
+<p style="text-align: center; color: #ababab !important;">The hyperbolic sine function is a one-to-one function and thus has an inverse. As usual, the graph of the inverse hyperbolic sine function sinh
+    <sup>-1</sup>(x) also denoted by arcsinh(x) by reflecting the graph of sinh(x) about the line y=x For all inverse hyperbolic functions but the inverse hyperbolic cotangent and the inverse hyperbolic cosecant, the domain of the real function is connected.
 </p>
 <p>\[sinh^{-1}(x)\space =\space ln(x+\sqrt{x^{2}+1})\]</p>
 <p>\[cosh^{-1}(x)\space =\space ln(x+\sqrt{x^{2}-1})\]</p>

--- a/study/inverseTrigonometryIdentities.html
+++ b/study/inverseTrigonometryIdentities.html
@@ -1,3 +1,15 @@
+<div class="back" onclick="openOption('appdata/menudata/trigonometry.html','Trigonometry')">
+    <img style="       
+            background-color: whitesmoke;
+            margin-bottom: 10px;
+            margin-left: 10px;
+            margin-top: 10px;
+            display: block !important;
+            height: 30px;
+            box-shadow: 0 0 10px white;
+            border-radius: 50%;
+            padding:5px;
+        " src="./icons/back.png" alt=""></div>
 <h2>Inverse Trigonometric Identities</h2>
 <br><br>
 <h4 style="text-align: center;">Negative Formulaes</h4>
@@ -19,10 +31,14 @@
 
 <p>\[sin(sin^{-1}x) = x, -1≤ x ≤1\]</p>
 <p>\[cos(cos^{-1}x) = x, -1≤ x ≤1\]</p>
-<p>\[tan(tan^{-1}x) = x, – ∞ < x < ∞ \]</p>
-        <p>\[cot(cot^{-1}x) = x, – ∞ < x < ∞ \]</p>
-                <p>\[sec(sec^{-1}x) = x, - ∞ < x ≤ 1\space or\space 1 ≤ x < ∞\]</p>
-                        <p>\[cosec(cosec^{-1}x) = x, - ∞ < x ≤ 1\space or\space 1 ≤ x < ∞\]</p>
+<p>\[tan(tan^{-1}x) = x, – ∞
+    < x < ∞ \]</p>
+        <p>\[cot(cot^{-1}x) = x, – ∞
+            < x < ∞ \]</p>
+                <p>\[sec(sec^{-1}x) = x, - ∞
+                    < x ≤ 1\space or\space 1 ≤ x < ∞\]</p>
+                        <p>\[cosec(cosec^{-1}x) = x, - ∞
+                            < x ≤ 1\space or\space 1 ≤ x < ∞\]</p>
                                 <h4 style="text-align : center;">Addition of Same functions</h4>
 
                                 <p>\[sin^{-1}x+sin^{-1}y = sin^{-1}(x\sqrt{1-y^2} + y\sqrt{1-x^2})\]</p>
@@ -43,125 +59,58 @@
                                     <tbody>
                                         <tr>
                                             <th scope="row">\[y=sin^{-1}(\frac{2x}{1+x^2})\]</th>
-                                            <td>\[\space \space \space \space \space \space \space
-                                                \space 2tan^{-1}x
-                                                \space \space \space \space \space \space \space \space
-                                                \space \space if
-                                                \space \space \space \space \space \space |x| \leqslant
-                                                1\] \[ \pi
-                                                \space - \space 2tan^{-1}x \space \space \space \space
-                                                \space \space
-                                                \space \space \space \space if \space \space \space
-                                                \space \space \space
-                                                x>1\]\[-(\pi + 2tan^{-1}x) \space \space \space \space
-                                                \space \space
-                                                \space \space \space if \space \space \space \space
-                                                \space \space \space
-                                                x<-1\] </td>
-                                            <td><img src="images/sininvgraph.png" class="img-fluid">
-                                            </td>
+                                            <td>\[\space \space \space \space \space \space \space \space 2tan^{-1}x \space \space \space \space \space \space \space \space \space \space if \space \space \space \space \space \space |x| \leqslant 1\] \[ \pi
+                                                \space - \space 2tan^{-1}x \space \space \space \space \space \space \space \space \space \space if \space \space \space \space \space \space x>1\]\[-(\pi + 2tan^{-1}x) \space \space \space \space \space
+                                                \space \space \space \space if \space \space \space \space \space \space \space x
+                                                <-1\] </td>
+                                                    <td><img src="images/sininvgraph.png" class="img-fluid">
+                                                    </td>
                                         </tr>
                                         <tr>
                                             <th scope="row">\[y=cos^{-1}(\frac{1-x^2}{1+x^2})\]</th>
-                                            <td>\[2tan^{-1}x \space \space \space \space \space \space
-                                                \space \space
-                                                \space if \space \space \space \space \space x \geqslant
-                                                0\] \[
-                                                -2tan^{-1}x \space \space \space \space \space \space if
-                                                \space \space
-                                                \space \space \space x<0\] </td>
-                                            <td><img src="images/cosinvgraph.png" class="img-fluid">
-                                            </td>
+                                            <td>\[2tan^{-1}x \space \space \space \space \space \space \space \space \space if \space \space \space \space \space x \geqslant 0\] \[ -2tan^{-1}x \space \space \space \space \space \space if \space \space \space
+                                                \space \space x
+                                                <0\] </td>
+                                                    <td><img src="images/cosinvgraph.png" class="img-fluid">
+                                                    </td>
                                         </tr>
                                         <tr>
                                             <th scope="row">\[y=tan^{-1}(\frac{2x}{1-x^2})\]</th>
-                                            <td>\[\space \space \space \space \space \space \space
-                                                \space 2tan^{-1}x
-                                                \space \space \space \space \space \space \space \space
-                                                \space \space
-                                                \space \space if \space \space \space \space \space
-                                                \space |x|<1\] \[ \pi \space + \space 2tan^{-1}x \space \space \space
-                                                    \space \space \space \space \space \space if \space \space \space
-                                                    \space \space \space x<-1\]\[-(\pi - 2tan^{-1}x) \space \space
-                                                    \space \space \space \space \space \space if \space \space \space
-                                                    \space \space \space x>1\]
+                                            <td>\[\space \space \space \space \space \space \space \space 2tan^{-1}x \space \space \space \space \space \space \space \space \space \space \space \space if \space \space \space \space \space \space |x|
+                                                <1\] \[
+                                                    \pi \space + \space 2tan^{-1}x \space \space \space \space \space \space \space \space \space if \space \space \space \space \space \space x<-1\]\[-(\pi - 2tan^{-1}x) \space \space \space \space \space \space
+                                                    \space \space if \space \space \space \space \space \space x>1\]
                                             </td>
                                             <td><img src="images/taninv.png" class="img-fluid"></td>
                                         </tr>
                                         <tr>
                                             <th scope="row">\[y=sin^{-1}(3x-4x^3)\]</th>
-                                            <td>\[-(\pi+3sin^{-1}x) \space \space \space \space \space
-                                                \space if \space
-                                                \space \space \space \space \space -1 \leqslant x
-                                                \leqslant
-                                                -\frac{1}{2}\]\[\space \space \space \space \space
-                                                \space \space \space
-                                                \space \space \space 3sin^{-1}x \space \space \space
-                                                \space \space
-                                                \space \space if \space \space \space \space \space
-                                                \space \space \space
-                                                - \frac{1}{2} \leqslant x \leqslant \frac{1}{2}\]\[\pi -
-                                                3sin^{-1}x
-                                                \space \space \space \space \space \space if \space
-                                                \space \space \space
-                                                \space \space \space \space \space \frac{1}{2} \leqslant
-                                                x \leqslant 1\]
+                                            <td>\[-(\pi+3sin^{-1}x) \space \space \space \space \space \space if \space \space \space \space \space \space -1 \leqslant x \leqslant -\frac{1}{2}\]\[\space \space \space \space \space \space \space \space \space
+                                                \space \space 3sin^{-1}x \space \space \space \space \space \space \space if \space \space \space \space \space \space \space \space - \frac{1}{2} \leqslant x \leqslant \frac{1}{2}\]\[\pi - 3sin^{-1}x \space
+                                                \space \space \space \space \space if \space \space \space \space \space \space \space \space \space \frac{1}{2} \leqslant x \leqslant 1\]
                                             </td>
                                             <td><img src="images/sin3inv.png" class="img-fluid"></td>
                                         </tr>
                                         <tr>
                                             <th scope="row">\[y=cos^{-1}(4x^3-3x)\]</th>
-                                            <td>\[3cos^{-1}x-2\pi \space \space \space \space \space
-                                                \space if \space
-                                                \space \space \space \space \space -1 \leqslant x
-                                                \leqslant
-                                                -\frac{1}{2}\]\[2\pi - 3cos^{-1}x \space \space \space
-                                                \space \space
-                                                \space if \space \space \space \space \space \space
-                                                -\frac{1}{2}
-                                                \leqslant x \leqslant \frac{1}{2}\]\[\space \space
-                                                \space \space \space
-                                                \space \space \space \space \space \space 3cos^{-1}x
-                                                \space \space
-                                                \space \space \space \space \space if \space \space
-                                                \space \space \space
-                                                \space \space \space \frac{1}{2} \leqslant x \leqslant
-                                                1\]
+                                            <td>\[3cos^{-1}x-2\pi \space \space \space \space \space \space if \space \space \space \space \space \space -1 \leqslant x \leqslant -\frac{1}{2}\]\[2\pi - 3cos^{-1}x \space \space \space \space \space \space if
+                                                \space \space \space \space \space \space -\frac{1}{2} \leqslant x \leqslant \frac{1}{2}\]\[\space \space \space \space \space \space \space \space \space \space \space 3cos^{-1}x \space \space \space \space
+                                                \space \space \space if \space \space \space \space \space \space \space \space \frac{1}{2} \leqslant x \leqslant 1\]
                                             </td>
                                             <td><img src="images/cos3inv.png" class="img-fluid"></td>
                                         </tr>
                                         <tr>
                                             <th scope="row">\[y=sin^{-1}(2x \sqrt{1-x^2})\]</th>
-                                            <td>\[-(\pi+2sin^{-1}x) \space \space \space \space \space
-                                                \space if \space
-                                                \space \space \space \space \space -1 \leqslant
-                                                x\leqslant
-                                                -\frac{1}{2}\]\[\space \space \space \space \space
-                                                \space \space \space
-                                                \space \space \space 2sin^{-1}x \space \space \space
-                                                \space \space
-                                                \space \space if \space \space \space \space \space
-                                                \space \space \space
-                                                -\frac{1}{\sqrt{2}} \leqslant x \leqslant
-                                                \frac{1}{\sqrt{2}}\]\[\pi -
-                                                2sin^{-1}x \space \space \space \space \space \space if
-                                                \space \space
-                                                \space \space \space \space \frac{1}{\sqrt{2}} \leqslant
-                                                x \leqslant 1\]
+                                            <td>\[-(\pi+2sin^{-1}x) \space \space \space \space \space \space if \space \space \space \space \space \space -1 \leqslant x\leqslant -\frac{1}{2}\]\[\space \space \space \space \space \space \space \space \space
+                                                \space \space 2sin^{-1}x \space \space \space \space \space \space \space if \space \space \space \space \space \space \space \space -\frac{1}{\sqrt{2}} \leqslant x \leqslant \frac{1}{\sqrt{2}}\]\[\pi -
+                                                2sin^{-1}x \space \space \space \space \space \space if \space \space \space \space \space \space \frac{1}{\sqrt{2}} \leqslant x \leqslant 1\]
                                             </td>
                                             <td><img src="images/sin2inv.png" class="img-fluid"></td>
                                         </tr>
                                         <tr>
                                             <th scope="row">\[y=cos^{-1}(2x^2-1)\]</th>
-                                            <td>\[\space \space \space \space 2cos^{-1}x \space \space
-                                                \space \space
-                                                \space \space if \space \space \space \space \space
-                                                \space \space \space
-                                                \space 0 \leqslant x \leqslant 1\]\[2\pi-2cos^{-1}x
-                                                \space \space \space
-                                                \space \space \space if \space \space \space
-                                                \space\space -1 \leqslant x
-                                                \leqslant 0\]
+                                            <td>\[\space \space \space \space 2cos^{-1}x \space \space \space \space \space \space if \space \space \space \space \space \space \space \space \space 0 \leqslant x \leqslant 1\]\[2\pi-2cos^{-1}x \space \space
+                                                \space \space \space \space if \space \space \space \space\space -1 \leqslant x \leqslant 0\]
                                             </td>
                                             <td><img src="images/cos2inv.png" class="img-fluid"></td>
                                         </tr>
@@ -172,13 +121,16 @@
                                 <table class="table table-bordered table-dark">
                                     <tbody>
                                         <tr>
-                                            <th scope="col">\[Function\]</strong></th>
-                                            <th scope="col">\[Domain\]</strong></th>
+                                            <th scope="col">\[Function\]</strong>
+                                            </th>
+                                            <th scope="col">\[Domain\]</strong>
+                                            </th>
                                             <th scope="col">
                                                 <p></p>\[Range \,of\, an\]</p>
                         <p>\[ Inverse\, Function\]</p>
                         </th>
-                        <th scope="col">\[Graphs\]</strong></th>
+                        <th scope="col">\[Graphs\]</strong>
+                        </th>
                         </tr>
                         <tr>
                             <th scope="row">
@@ -228,7 +180,7 @@
                 <td>
                     <p>\[0≤y≤\pi,\]</p>
                     <p>\[y \neq \frac{\pi}{2}\]
-                    <p>
+                        <p>
                 </td>
                 <td><img src="images/arcsec.png" class="img-fluid"></td>
                 </tr>

--- a/study/trigonometryFunctions.html
+++ b/study/trigonometryFunctions.html
@@ -1,14 +1,29 @@
+<div class="back" onclick="openOption('appdata/menudata/trigonometry.html','Trigonometry')">
+    <img style="       
+            background-color: whitesmoke;
+            margin-bottom: 10px;
+            margin-left: 10px;
+            margin-top: 10px;
+            display: block !important;
+            height: 30px;
+            box-shadow: 0 0 10px white;
+            border-radius: 50%;
+            padding:5px;
+        " src="./icons/back.png" alt=""></div>
 <h3 style="text-align: center;">Domain,Range,Period and Graph of Trigonometric Functions</h3>
 <table class="table table-bordered table-dark">
     <tbody>
         <tr>
-            <th scope="col">\[Function\]</strong></th>
-            <th scope="col">\[Domain\]</strong></th>
+            <th scope="col">\[Function\]</strong>
+            </th>
+            <th scope="col">\[Domain\]</strong>
+            </th>
             <th scope="col">
                 <p></p>\[Range \,and\,Period\,of\, a\]</p>
                 <p>\[ Trigonometric\, Function\]</p>
             </th>
-            <th scope="col">\[Graphs\]</strong></th>
+            <th scope="col">\[Graphs\]</strong>
+            </th>
         </tr>
         <tr>
             <th scope="row">

--- a/study/trigonometryIdentities.html
+++ b/study/trigonometryIdentities.html
@@ -1,3 +1,15 @@
+<div class="back" onclick="openOption('appdata/menudata/trigonometry.html','Trigonometry')">
+    <img style="       
+            background-color: whitesmoke;
+            margin-bottom: 10px;
+            margin-left: 10px;
+            margin-top: 10px;
+            display: block !important;
+            height: 30px;
+            box-shadow: 0 0 10px white;
+            border-radius: 50%;
+            padding:5px;
+        " src="./icons/back.png" alt=""></div>
 <div class="stopwrap">
     <div class="coll">
         <div class="left">
@@ -47,13 +59,13 @@
     <div class="coll">
         <div class="left">
             <h4>Double angle Identities</h4>
-            <p>\[sin\space 2 \theta=2 \space sin\space\theta\space
-                cos\space\theta\]</p>
+            <p>\[sin\space 2 \theta=2 \space sin\space\theta\space cos\space\theta\]
+            </p>
             <p>\[cos\space 2 \theta= cos^2 \space\theta - sin^2 \space\theta\]</p>
             <p>\[cos\space 2 \theta = 2\space cos^2\space\theta - 1\]</p>
             <p>\[cos\space 2 \theta= 1- 2\space sin^2 \space\theta\]</p>
-            <p>\[tan\space 2 \theta=\frac{2\space tan \theta}{1 - tan^2
-                \theta}\]</p>
+            <p>\[tan\space 2 \theta=\frac{2\space tan \theta}{1 - tan^2 \theta}\]
+            </p>
         </div>
         <div class="right">
             <h4>Cofunction Identities</h4>
@@ -61,14 +73,14 @@
                 <div class="col1">
                     <p>\[sin \space (\frac{π}{2} - \theta ) = cos\space\theta\]</p>
                     <p>\[tan \space (\frac{π}{2} - \theta ) = cot\space\theta\]</p>
-                    <p>\[cosec \space (\frac{π}{2} - \theta ) =
-                        sec\space\theta\]</p>
+                    <p>\[cosec \space (\frac{π}{2} - \theta ) = sec\space\theta\]
+                    </p>
                 </div>
                 <div class="col2">
                     <p>\[cos \space (\frac{π}{2} - \theta ) = sin\space\theta\]</p>
                     <p>\[cot \space (\frac{π}{2} - \theta ) = tan\space\theta\]</p>
-                    <p>\[sec \space (\frac{π}{2} - \theta ) =
-                        cosec\space\theta\]</p>
+                    <p>\[sec \space (\frac{π}{2} - \theta ) = cosec\space\theta\]
+                    </p>
                 </div>
             </div>
         </div>
@@ -82,134 +94,90 @@
         </div>
         <div class="right">
             <h4>Sum/Difference Identities</h4>
-            <p>\[sin (\theta ± \phi ) = sin\space\theta cos\space\phi ±
-                cos\space\theta sin\space\phi\]
+            <p>\[sin (\theta ± \phi ) = sin\space\theta cos\space\phi ± cos\space\theta sin\space\phi\]
             </p>
-            <p>\[cos (\theta ± \phi ) = cos\space\theta cos\space\phi ∓
-                sin\space\theta sin\space\phi\]
+            <p>\[cos (\theta ± \phi ) = cos\space\theta cos\space\phi ∓ sin\space\theta sin\space\phi\]
             </p>
-            <p>\[tan (\theta ± \phi ) = \frac{tan \space\theta ± tan \space\phi}{1 ∓
-                tan \space\theta
-                tan\space\phi}\]</p>
+            <p>\[tan (\theta ± \phi ) = \frac{tan \space\theta ± tan \space\phi}{1 ∓ tan \space\theta tan\space\phi}\]
+            </p>
         </div>
     </div>
     <div class="coll">
         <div class="left">
             <h4>Product-to-Sum Identities</h4>
-            <p>\[2 cos \space \theta \cos \space \varphi = {{\cos(\theta - \varphi)
-                + \cos(\theta +
-                \varphi)}}\]</p>
-            <p>\[2 sin \space \theta \sin \space \varphi = {{\cos(\theta - \varphi)
-                - \cos(\theta +
-                \varphi)}}\]</p>
-            <p>\[2 sin \space \theta \cos \space \varphi = {{\sin(\theta + \varphi)
-                + \sin(\theta -
-                \varphi)}}\]</p>
-            <p>\[2 cos \space \theta \sin \space \varphi = {{\sin(\theta + \varphi)
-                - \sin(\theta -
-                \varphi)}}\]</p>
-            <p>\[2 tan \space \theta \tan \space \varphi
-                =\frac{\cos(\theta-\varphi)-\cos(\theta+\varphi)}{\cos(\theta-\varphi)+\cos(\theta+\varphi)}\]
+            <p>\[2 cos \space \theta \cos \space \varphi = {{\cos(\theta - \varphi) + \cos(\theta + \varphi)}}\]
+            </p>
+            <p>\[2 sin \space \theta \sin \space \varphi = {{\cos(\theta - \varphi) - \cos(\theta + \varphi)}}\]
+            </p>
+            <p>\[2 sin \space \theta \cos \space \varphi = {{\sin(\theta + \varphi) + \sin(\theta - \varphi)}}\]
+            </p>
+            <p>\[2 cos \space \theta \sin \space \varphi = {{\sin(\theta + \varphi) - \sin(\theta - \varphi)}}\]
+            </p>
+            <p>\[2 tan \space \theta \tan \space \varphi =\frac{\cos(\theta-\varphi)-\cos(\theta+\varphi)}{\cos(\theta-\varphi)+\cos(\theta+\varphi)}\]
             </p>
         </div>
         <div class="right">
             <h4>Sum-to-Product Identities</h4>
-            <p>\[sin \space \theta \pm \sin \space \varphi = 2\sin\left(
-                \frac{\theta \pm \varphi}{2}
-                \right) \cos\left( \frac{\theta \mp \varphi}{2} \right)\]</p>
-            <p>\[cos \space \theta + \cos \space \varphi = 2\cos\left( \frac{\theta
-                + \varphi} {2}
-                \right)
-                \cos\left( \frac{\theta - \varphi}{2} \right)\]</p>
-            <p>\[cos \space \theta - \cos \space \varphi = -2\sin\left( \frac{\theta
-                +
-                \varphi}{2}\right)
-                \sin\left(\frac{\theta - \varphi}{2}\right)\]</p>
+            <p>\[sin \space \theta \pm \sin \space \varphi = 2\sin\left( \frac{\theta \pm \varphi}{2} \right) \cos\left( \frac{\theta \mp \varphi}{2} \right)\]</p>
+            <p>\[cos \space \theta + \cos \space \varphi = 2\cos\left( \frac{\theta + \varphi} {2} \right) \cos\left( \frac{\theta - \varphi}{2} \right)\]</p>
+            <p>\[cos \space \theta - \cos \space \varphi = -2\sin\left( \frac{\theta + \varphi}{2}\right) \sin\left(\frac{\theta - \varphi}{2}\right)\]</p>
         </div>
     </div>
     <div class="coll">
         <div class="left">
             <h4>Triple Angle Identities</h4>
-            <p>\[sin\space 3 \theta=3 \space sin\space\theta - 4 \space sin^3
-                \space\theta\]</p>
-            <p>\[cos\space 3 \theta=4 \space cos^3\space\theta - 3 \space cos
-                \space\theta\]</p>
-            <p>\[tan\space 3 \theta=\frac{3 \space tan\space\theta - tan^3
-                \space\theta}{1 - 3 \space
-                tan^2
-                \space \theta}\]</p>
+            <p>\[sin\space 3 \theta=3 \space sin\space\theta - 4 \space sin^3 \space\theta\]
+            </p>
+            <p>\[cos\space 3 \theta=4 \space cos^3\space\theta - 3 \space cos \space\theta\]
+            </p>
+            <p>\[tan\space 3 \theta=\frac{3 \space tan\space\theta - tan^3 \space\theta}{1 - 3 \space tan^2 \space \theta}\]</p>
         </div>
         <div class="right">
             <h4>Conditional Identities</h4>
             <p>\[Given:\space A\,+\,B\,+\,C\,=\,π\]</p>
-            <p>\[sin\space 2A\space+\space sin\space 2B\space+\space sin\space
-                2C\space=4\,sin\,A\,sin\,B\,sin\,C\]</p>
-            <p>\[sin\space A\space+\space sin\space B\space+\space sin\space
-                C\space=4\,cos\,\frac{A}{2}\,cos\,\frac{B}{2}\,cos\,\frac{C}{2}\]</p>
-            <p>\[cos\space 2A\space+\space cos\space 2B\space+\space cos\space
-                2C\space=-\,1\,-\,4\,cos\,A\,cos\,B\,cos\,C\]</p>
-            <p>\[cos\space A\space+\space cos\space B\space+\space cos\space
-                C\space=1\,+\,4\,sin\,\frac{A}{2}\,sin\,\frac{B}{2}\,sin\,\frac{C}{2}\]</p>
-            <p>\[tan\space A\space+\space tan\space B\space+\space tan\space
-                C\space=\,tan\,A\,tan\,B\,tan\,C\]</p>
-            <p>\[tan\space \frac{A}{2}\space tan\space \frac{B}{2}\space+\space
-                tan\space \frac{B}{2}\space tan\space \frac{C}{2}\space+\space
-                tan\space \frac{C}{2}\space tan\space \frac{A}{2}\space=\,1\]</p>
-            <p>\[cot\space \frac{A}{2}\space+\space cot\space
-                \frac{B}{2}\space+\space cot\space
-                \frac{C}{2}\space=\,cot\,\frac{A}{2}\,cot\,\frac{B}{2}\,cot\,\frac{C}{2}\]</p>
-            <p>\[cot\space A\space cot\space B\space+\space cot\space B\space
-                cot\space C\space+\space cot\space C\space cot\space
-                A\space=\,1\]</p>
+            <p>\[sin\space 2A\space+\space sin\space 2B\space+\space sin\space 2C\space=4\,sin\,A\,sin\,B\,sin\,C\]
+            </p>
+            <p>\[sin\space A\space+\space sin\space B\space+\space sin\space C\space=4\,cos\,\frac{A}{2}\,cos\,\frac{B}{2}\,cos\,\frac{C}{2}\]
+            </p>
+            <p>\[cos\space 2A\space+\space cos\space 2B\space+\space cos\space 2C\space=-\,1\,-\,4\,cos\,A\,cos\,B\,cos\,C\]
+            </p>
+            <p>\[cos\space A\space+\space cos\space B\space+\space cos\space C\space=1\,+\,4\,sin\,\frac{A}{2}\,sin\,\frac{B}{2}\,sin\,\frac{C}{2}\]
+            </p>
+            <p>\[tan\space A\space+\space tan\space B\space+\space tan\space C\space=\,tan\,A\,tan\,B\,tan\,C\]
+            </p>
+            <p>\[tan\space \frac{A}{2}\space tan\space \frac{B}{2}\space+\space tan\space \frac{B}{2}\space tan\space \frac{C}{2}\space+\space tan\space \frac{C}{2}\space tan\space \frac{A}{2}\space=\,1\]</p>
+            <p>\[cot\space \frac{A}{2}\space+\space cot\space \frac{B}{2}\space+\space cot\space \frac{C}{2}\space=\,cot\,\frac{A}{2}\,cot\,\frac{B}{2}\,cot\,\frac{C}{2}\]
+            </p>
+            <p>\[cot\space A\space cot\space B\space+\space cot\space B\space cot\space C\space+\space cot\space C\space cot\space A\space=\,1\]
+            </p>
         </div>
     </div>
     <div class="coll">
         <div class="left">
             <h4>Trigonometric Identities involving three different angles</h4>
-            <p>\[1) \space sin\space (A+B+C) \space = sinAcosBcosC \space + \space
-                sinBcosAcosC \space + \space sinCcosAcosB \space - \space
-                sinAsinBsinC \]\[=cosAcosBcosC \space [tanA
-                +tanB+tanc-tanAtanBtanc]\]</p>
-            <p>\[2) \space cos\space (A+B+C) \space = cosAcosBcosC \space - \space
-                sinAsinBcosC \space \space sinAcosBsinC \space - \space cosAsinBsinC
-                \]\[=cosAcosBcosC \space [1-tanAtanB - tanBtanC-tanCtanA]\]</p>
-            <p>\[3) \space tan\space (A+B+C) \space = \frac{tanA \space + \space
-                tanB \space + \space tanC \space - \space
-                tanAtanBtanC}{1-tanAtanB-tanBtanC-tanCtanA}\]</p>
+            <p>\[1) \space sin\space (A+B+C) \space = sinAcosBcosC \space + \space sinBcosAcosC \space + \space sinCcosAcosB \space - \space sinAsinBsinC \]\[=cosAcosBcosC \space [tanA +tanB+tanc-tanAtanBtanc]\]
+            </p>
+            <p>\[2) \space cos\space (A+B+C) \space = cosAcosBcosC \space - \space sinAsinBcosC \space \space sinAcosBsinC \space - \space cosAsinBsinC \]\[=cosAcosBcosC \space [1-tanAtanB - tanBtanC-tanCtanA]\]</p>
+            <p>\[3) \space tan\space (A+B+C) \space = \frac{tanA \space + \space tanB \space + \space tanC \space - \space tanAtanBtanC}{1-tanAtanB-tanBtanC-tanCtanA}\]
+            </p>
             <br>
             <h4>Sine and Cosine Series</h4>
-            <p>\[sin\alpha + sin(\alpha + \beta) + sin(\alpha +2\beta)
-                +...+sin(\alpha+ \overline{n-1}\beta)\]\[=\frac{sin(
-                \alpha+(\frac{n-1}{2})\beta)
-                sin(\frac{n\beta}{2})}{sin(\frac{\beta}{2})}\]</p>
-            <p>\[cos\alpha + cos(\alpha + \beta) + cos(\alpha +2\beta)
-                +...+cos(\alpha+ \overline{n-1}\beta)\]\[=\frac{cos(
-                \alpha+(\frac{n-1}{2})\beta)
-                sin(\frac{n\beta}{2})}{sin(\frac{\beta}{2})}\]</p>
+            <p>\[sin\alpha + sin(\alpha + \beta) + sin(\alpha +2\beta) +...+sin(\alpha+ \overline{n-1}\beta)\]\[=\frac{sin( \alpha+(\frac{n-1}{2})\beta) sin(\frac{n\beta}{2})}{sin(\frac{\beta}{2})}\]
+            </p>
+            <p>\[cos\alpha + cos(\alpha + \beta) + cos(\alpha +2\beta) +...+cos(\alpha+ \overline{n-1}\beta)\]\[=\frac{cos( \alpha+(\frac{n-1}{2})\beta) sin(\frac{n\beta}{2})}{sin(\frac{\beta}{2})}\]
+            </p>
             <br>
             <h4>IMPORTANT RESULTS</h4>
-            <p>\[1) \space sin\theta \space sin(60^{\circ}-\theta) \space
-                sin(60^{\circ}+\theta) \space = \space \frac{1}{4}sin3\theta\]</p>
-            <p>\[2) \space cos\theta \space cos(60^{\circ}-\theta) \space
-                cos(60^{\circ}+\theta) \space = \space \frac{1}{4}cos3\theta\]</p>
-            <p>\[3) \space tan\theta \space tan(60^{\circ}-\theta) \space
-                tan(60^{\circ}+\theta) \space = \space tan3\theta\]</p>
-            <p>\[4) \space cot\theta \space cot(60^{\circ}-\theta) \space
-                cot(60^{\circ}+\theta) \space = \space cot3\theta\]</p>
-            <p>\[5) \space (i) sin^2\theta \space + \space sin^2(60^{\circ}+\theta)
-                \space + \space sin^2(60^{\circ}-\theta) \space = \frac{3}{2}\]</p>
-            <p>\[\space \space \space \space (ii) cos^2\theta \space + \space
-                cos^2(60^{\circ}+\theta) \space + \space cos^2(60^{\circ}-\theta)
-                \space = \frac{3}{2}\]</p>
-            <p>\[6) \space If \space tanA+tanB+tanC \space = \space
-                tanAtanBtanC,\]\[then \space A+B+C \space = \space n\pi, \space n
-                \in I\]</p>
-            <p>\[7) \space If \space tanAtanB+tanBtanC+tanCtanA \space = \space
-                1,\]\[\space \space then \space A+B+C \space = \space
-                (2n+1)\frac{\pi}{2}, \space n \in I\]</p>
-            <p>\[8) \space cos\theta \space cos2\theta \space cos4\theta .....
-                cos(2^{n-1}\theta) \space = \space
-                \frac{sin(2^n\theta)}{2^nsin\theta}\]</p>
+            <p>\[1) \space sin\theta \space sin(60^{\circ}-\theta) \space sin(60^{\circ}+\theta) \space = \space \frac{1}{4}sin3\theta\]</p>
+            <p>\[2) \space cos\theta \space cos(60^{\circ}-\theta) \space cos(60^{\circ}+\theta) \space = \space \frac{1}{4}cos3\theta\]</p>
+            <p>\[3) \space tan\theta \space tan(60^{\circ}-\theta) \space tan(60^{\circ}+\theta) \space = \space tan3\theta\]</p>
+            <p>\[4) \space cot\theta \space cot(60^{\circ}-\theta) \space cot(60^{\circ}+\theta) \space = \space cot3\theta\]</p>
+            <p>\[5) \space (i) sin^2\theta \space + \space sin^2(60^{\circ}+\theta) \space + \space sin^2(60^{\circ}-\theta) \space = \frac{3}{2}\]</p>
+            <p>\[\space \space \space \space (ii) cos^2\theta \space + \space cos^2(60^{\circ}+\theta) \space + \space cos^2(60^{\circ}-\theta) \space = \frac{3}{2}\]</p>
+            <p>\[6) \space If \space tanA+tanB+tanC \space = \space tanAtanBtanC,\]\[then \space A+B+C \space = \space n\pi, \space n \in I\]</p>
+            <p>\[7) \space If \space tanAtanB+tanBtanC+tanCtanA \space = \space 1,\]\[\space \space then \space A+B+C \space = \space (2n+1)\frac{\pi}{2}, \space n \in I\]</p>
+            <p>\[8) \space cos\theta \space cos2\theta \space cos4\theta ..... cos(2^{n-1}\theta) \space = \space \frac{sin(2^n\theta)}{2^nsin\theta}\]
+            </p>
             <p>\[9) \space cotA \space - \space tanA \space = \space 2cot2A\]</p>
         </div>
 

--- a/study/trigonometryValues.html
+++ b/study/trigonometryValues.html
@@ -1,3 +1,15 @@
+<div class="back" onclick="openOption('appdata/menudata/trigonometry.html','Trigonometry')">
+    <img style="       
+            background-color: whitesmoke;
+            margin-bottom: 10px;
+            margin-left: 10px;
+            margin-top: 10px;
+            display: block !important;
+            height: 30px;
+            box-shadow: 0 0 10px white;
+            border-radius: 50%;
+            padding:5px;
+        " src="./icons/back.png" alt=""></div>
 <div class="stopwrap">
     <table class="table table-bordered table-dark">
         <thead>
@@ -62,46 +74,37 @@
         </tbody>
     </table>
     <h2>\[Values \space of \space some \space T-Ratios \space for \space many \space angles \]</h2>
-    <p>\[1) \space sin(7.5^{\circ})= \frac{\sqrt{2-\sqrt{2+\sqrt{3}}}}{2}= cos(82.5^{\circ})= sin
-        \frac{\pi}{24}\]</p>
-    <p>\[2) \space cos(7.5^{\circ})= \frac{\sqrt{2+\sqrt{2+\sqrt{3}}}}{2}= sin(82.5^{\circ})= cos
-        \frac{\pi}{24}\]</p>
-    <p>\[3) \space tan(7.5^{\circ})= \sqrt{6}-\sqrt{3}+\sqrt{2}-2=(\sqrt{2}-1)(\sqrt{3}-\sqrt{2})=
-        cot(82.5^{\circ})= tan\frac{\pi}{24}\]</p>
-    <p>\[4) \space cot(7.5^{\circ})= \sqrt{6}+\sqrt{3}+\sqrt{2}+2=(\sqrt{2}+1)(\sqrt{3}+\sqrt{2})=
-        tan(82.5^{\circ})= cot\frac{\pi}{24}\]</p>
-    <p>\[5) \space sin15^{\circ}= \frac{\sqrt{3}-1}{2\sqrt{2}}= cos75^{\circ}= sin
-        \frac{\pi}{12}\]</p>
-    <p>\[6) \space cos15^{\circ}= \frac{\sqrt{3}+1}{2\sqrt{2}}= sin75^{\circ}= cos
-        \frac{\pi}{12}\]</p>
+    <p>\[1) \space sin(7.5^{\circ})= \frac{\sqrt{2-\sqrt{2+\sqrt{3}}}}{2}= cos(82.5^{\circ})= sin \frac{\pi}{24}\]
+    </p>
+    <p>\[2) \space cos(7.5^{\circ})= \frac{\sqrt{2+\sqrt{2+\sqrt{3}}}}{2}= sin(82.5^{\circ})= cos \frac{\pi}{24}\]
+    </p>
+    <p>\[3) \space tan(7.5^{\circ})= \sqrt{6}-\sqrt{3}+\sqrt{2}-2=(\sqrt{2}-1)(\sqrt{3}-\sqrt{2})= cot(82.5^{\circ})= tan\frac{\pi}{24}\]</p>
+    <p>\[4) \space cot(7.5^{\circ})= \sqrt{6}+\sqrt{3}+\sqrt{2}+2=(\sqrt{2}+1)(\sqrt{3}+\sqrt{2})= tan(82.5^{\circ})= cot\frac{\pi}{24}\]</p>
+    <p>\[5) \space sin15^{\circ}= \frac{\sqrt{3}-1}{2\sqrt{2}}= cos75^{\circ}= sin \frac{\pi}{12}\]
+    </p>
+    <p>\[6) \space cos15^{\circ}= \frac{\sqrt{3}+1}{2\sqrt{2}}= sin75^{\circ}= cos \frac{\pi}{12}\]
+    </p>
     <p>\[7) \space tan15^{\circ}= 2-\sqrt{3}= cot75^{\circ}= tan\frac{\pi}{12}\]</p>
     <p>\[8) \space cot15^{\circ}= 2+\sqrt{3}= tan75^{\circ}= cot\frac{\pi}{12}\]</p>
-    <p>\[9) \space sin18^{\circ}= \frac{\sqrt{5}-1}{4}= \sqrt{\frac{3-\sqrt{5}}{8}}
-        = cos72^{\circ}= sin\frac{\pi}{10} \]</p>
-    <p>\[10) \space cos18^{\circ}= \frac{\sqrt{10+2\sqrt{5}}}{4}= \sqrt{\frac{5+\sqrt{5}}{8}}
-        = sin72^{\circ}= cos\frac{\pi}{10} \]</p>
+    <p>\[9) \space sin18^{\circ}= \frac{\sqrt{5}-1}{4}= \sqrt{\frac{3-\sqrt{5}}{8}} = cos72^{\circ}= sin\frac{\pi}{10} \]</p>
+    <p>\[10) \space cos18^{\circ}= \frac{\sqrt{10+2\sqrt{5}}}{4}= \sqrt{\frac{5+\sqrt{5}}{8}} = sin72^{\circ}= cos\frac{\pi}{10} \]</p>
     <p>\[11) \space tan18^{\circ}= \sqrt{1-\frac{2\sqrt{5}}{5}}= cot72^{\circ}= tan\frac{\pi}{10}\]</p>
     <p>\[12) \space cot18^{\circ}= \sqrt{5+2\sqrt{5}}= tan72^{\circ}= cot\frac{\pi}{10}\]</p>
-    <p>\[13) \space sin(22.5^{\circ})= \frac{\sqrt{2-\sqrt{2}}}{2}= \sqrt{\frac{4-\sqrt{8}}{8}}
-        = cos(67.5^{\circ})= sin\frac{\pi}{8}\]</p>
-    <p>\[14) \space cos(22.5^{\circ})= \frac{\sqrt{2+\sqrt{2}}}{2}= \sqrt{\frac{4+\sqrt{8}}{8}}
-        = sin(67.5^{\circ})= cos\frac{\pi}{8}\]</p>
+    <p>\[13) \space sin(22.5^{\circ})= \frac{\sqrt{2-\sqrt{2}}}{2}= \sqrt{\frac{4-\sqrt{8}}{8}} = cos(67.5^{\circ})= sin\frac{\pi}{8}\]</p>
+    <p>\[14) \space cos(22.5^{\circ})= \frac{\sqrt{2+\sqrt{2}}}{2}= \sqrt{\frac{4+\sqrt{8}}{8}} = sin(67.5^{\circ})= cos\frac{\pi}{8}\]</p>
     <p>\[15) \space tan(22.5^{\circ})=\sqrt{2}-1=cot(67.5^{\circ})= tan\frac{\pi}{8}\]</p>
     <p>\[16) \space cot(22.5^{\circ})=1+\sqrt{2}=tan(67.5^{\circ})= cot\frac{\pi}{8}\]</p>
-    <p>\[17) \space sin36^{\circ}= \frac{\sqrt{10-2\sqrt{5}}}{4}= \sqrt{\frac{5-\sqrt{5}}{8}}=
-        cos54^{\circ}= sin\frac{\pi}{5}\]</p>
-    <p>\[18) \space cos36^{\circ}= \frac{\sqrt{5}+1}{4}= \sqrt{\frac{3+\sqrt{5}}{8}}= sin54^{\circ}=cos
-        \frac{\pi}{5}\]</p>
-    <p>\[19) \space tan36^{\circ}= \sqrt{5-2\sqrt{5}}= cot54^{\circ}= tan
-        \frac{\pi}{5}\]</p>
-    <p>\[20) \space cot36^{\circ}= \sqrt{\frac{5+2\sqrt{5}}{5}}= tan54^{\circ}= cot
-        \frac{\pi}{5}\]</p>
-    <p>\[21) \space sin(37.5^{\circ})= \frac{\sqrt{2-\sqrt{2-\sqrt{3}}}}{2}= cos(52.5^{\circ})= sin
-        \frac{5\pi}{24}\]</p>
-    <p>\[22) \space cos(37.5^{\circ})= \frac{\sqrt{2+\sqrt{2-\sqrt{3}}}}{2}= sin(52.5^{\circ})= cos
-        \frac{5\pi}{24}\]</p>
-    <p>\[23) \space tan(37.5^{\circ})= \sqrt{6}+\sqrt{3}-\sqrt{2}-2=(\sqrt{2}+1)(\sqrt{3}-\sqrt{2})=
-        cot(52.5^{\circ})= tan\frac{5\pi}{24}\]</p>
-    <p>\[24) \space cot(37.5^{\circ})= \sqrt{6}-\sqrt{3}-\sqrt{2}+2=(\sqrt{2}-1)(\sqrt{3}+\sqrt{2})=
-        tan(52.5^{\circ})= cot\frac{5\pi}{24} \]</p>
+    <p>\[17) \space sin36^{\circ}= \frac{\sqrt{10-2\sqrt{5}}}{4}= \sqrt{\frac{5-\sqrt{5}}{8}}= cos54^{\circ}= sin\frac{\pi}{5}\]</p>
+    <p>\[18) \space cos36^{\circ}= \frac{\sqrt{5}+1}{4}= \sqrt{\frac{3+\sqrt{5}}{8}}= sin54^{\circ}=cos \frac{\pi}{5}\]
+    </p>
+    <p>\[19) \space tan36^{\circ}= \sqrt{5-2\sqrt{5}}= cot54^{\circ}= tan \frac{\pi}{5}\]
+    </p>
+    <p>\[20) \space cot36^{\circ}= \sqrt{\frac{5+2\sqrt{5}}{5}}= tan54^{\circ}= cot \frac{\pi}{5}\]
+    </p>
+    <p>\[21) \space sin(37.5^{\circ})= \frac{\sqrt{2-\sqrt{2-\sqrt{3}}}}{2}= cos(52.5^{\circ})= sin \frac{5\pi}{24}\]
+    </p>
+    <p>\[22) \space cos(37.5^{\circ})= \frac{\sqrt{2+\sqrt{2-\sqrt{3}}}}{2}= sin(52.5^{\circ})= cos \frac{5\pi}{24}\]
+    </p>
+    <p>\[23) \space tan(37.5^{\circ})= \sqrt{6}+\sqrt{3}-\sqrt{2}-2=(\sqrt{2}+1)(\sqrt{3}-\sqrt{2})= cot(52.5^{\circ})= tan\frac{5\pi}{24}\]</p>
+    <p>\[24) \space cot(37.5^{\circ})= \sqrt{6}-\sqrt{3}-\sqrt{2}+2=(\sqrt{2}-1)(\sqrt{3}+\sqrt{2})= tan(52.5^{\circ})= cot\frac{5\pi}{24} \]</p>
 </div>


### PR DESCRIPTION
## Closes Issue #5442 

#### Describe the changes you've made

I have successfully added Backward button in Trigonometry Functions, Trigonometry Identities, and Hyperbolic Trigonometry Identities page also some more theory and Calculator page under Trigonometry doesn't consist of Backward button, so in rest of the pages also I have added backward button successfully.

## Screenshots

![image](https://user-images.githubusercontent.com/61961107/137596738-bd279d47-f796-4183-a992-f25f01680892.png)

![image](https://user-images.githubusercontent.com/61961107/137596743-ba58067a-9fd8-4aa7-b42f-482573793b9d.png)

![image](https://user-images.githubusercontent.com/61961107/137596749-053710cc-360f-477d-bbde-928962b08220.png)

Kindly merge my PR under Hactoberfest2021
